### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # box-mcp-server
+[![smithery badge](https://smithery.ai/badge/box-mcp-server)](https://smithery.ai/server/box-mcp-server)
 
 ## Usage
+
+### Installing via Smithery
+
+To install Box for Claude Desktop automatically via [Smithery](https://smithery.ai/server/box-mcp-server):
+
+```bash
+npx -y @smithery/cli install box-mcp-server --client claude
+```
 
 ### Developer Token Authorization
 This MCP server currently supports only Developer Token authentication.


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Box for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/box-mcp-server

Let me know if any tweaks have to be made!