### PR TITLE
Fix punycode warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1307,14 +1307,16 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.1.0.tgz",
-      "integrity": "sha512-o5PIPz0vc1bJYXS0oLvRr8yUOzYtxEFL1rWP4aiO8qLslCksmbKhONy6CTpq0WPuIXUt2YuXoRtVA2EcLix3fw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.4.1.tgz",
+      "integrity": "sha512-wS6YC4lkUZ9QpP+/7NBTlVNiEvsnyl0xF7rRusLF+RsG0xDPc/zWR7fEEyhKnnNutGsDAZh59l/AeoWGwIb1+g==",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
+        "eventsource": "^3.0.2",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -1928,9 +1930,9 @@
       "license": "MIT"
     },
     "node_modules/box-typescript-sdk-gen": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/box-typescript-sdk-gen/-/box-typescript-sdk-gen-1.10.0.tgz",
-      "integrity": "sha512-S0Ezuxz1cBAVRwSHthLC5Ux6B6CIIq5PXvCGN8IDMEef6QhCQ0dA7Gs5tpVhvHMXVqpXos0xcGauI4LECasrXA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/box-typescript-sdk-gen/-/box-typescript-sdk-gen-1.11.0.tgz",
+      "integrity": "sha512-g5UvZeV6sAVIjtg5yDNGtKSzEGBK1nDn5AnHczsmWbNIoxxKsy/NrsfKKQgKJbOyqYOE+bwotxL5GCufSCY9DA==",
       "license": "Apache-2.0",
       "dependencies": {
         "buffer": "^6.0.3",
@@ -2567,6 +2569,27 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.5.tgz",
+      "integrity": "sha512-LT/5J605bx5SNyE+ITBDiM3FxffBiq9un7Vx0EwMDM3vg8sWKx/tO2zC+LMqZ+smAM0F2hblaDZUVZF0te2pSw==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
+      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -5384,6 +5407,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
+      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+import process from 'process';
+if (process.env.NODE_ENV !== 'development') {
+  process.removeAllListeners('warning');
+}
+
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {


### PR DESCRIPTION
fixes #8 

This pull request includes a small change to the `src/index.ts` file. The change imports the `process` module and conditionally removes all warning listeners when the `NODE_ENV` environment variable is not set to 'development'. 

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R3-R7): Imported the `process` module and removed all warning listeners if `NODE_ENV` is not 'development'.